### PR TITLE
Fix usage with rootless containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       context: ./.docker/composer/
       dockerfile: Dockerfile
     container_name: composer
-    user: 1000:1001
+    userns_mode: "keep-id"
     volumes:
       - ./:/app/laravel
     networks:


### PR DESCRIPTION
`userns_mode` decides how to map the user UID and GID to the container UID and GID, apparently, for rootless containers. Setting this to keep-id sets the UID and GID used in the container to the same as the one on the host, fixing our issues.

If this change does not work for you, as in, it breaks the container for you, we can just use the `COMPOSER_ALLOW_SUPERUSER` environment variable instead. Plox check out :D